### PR TITLE
Add scopes parameter

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,6 +30,7 @@ type app struct {
 	clientID     string
 	clientSecret string
 	redirectURI  string
+	scopes		 string
 
 	verifier *oidc.IDTokenVerifier
 	provider *oidc.Provider

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -201,6 +201,7 @@ func cmd() *cobra.Command {
 	c.Flags().StringVar(&a.clientID, "client-id", "k8s-auth", "OAuth2 client ID of this application.")
 	c.Flags().StringVar(&a.clientSecret, "client-secret", "ZXhhbXBsZS1hcHAtc2VjcmV0", "OAuth2 client secret of this application.")
 	c.Flags().StringVar(&a.redirectURI, "redirect-uri", "http://127.0.0.1:5555", "Callback URL for OAuth2 responses.")
+	c.Flags().StringVar(&a.scopes, "scopes", "openid,profile,email,groups", "OAuth2 scopes values.")
 	c.Flags().StringVar(&issuerURL, "issuer", "https://dex.example.com", "URL of the OpenID Connect issuer.")
 	c.Flags().StringVar(&listen, "listen", "http://127.0.0.1:5555", "HTTP(S) address to listen at.")
 	c.Flags().StringVar(&tlsCert, "tls-cert", "", "X509 cert file to present when serving HTTPS.")
@@ -250,7 +251,7 @@ func (a *app) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	authCodeURL := ""
-	scopes = append(scopes, "openid", "profile", "email", "groups")
+	scopes = append(scopes, strings.Split(a.scopes, ",")...)
 	if a.offlineAsScope {
 		scopes = append(scopes, "offline_access")
 		authCodeURL = a.oauth2Config(scopes).AuthCodeURL(authenticationState)


### PR DESCRIPTION
## Synopsis

Some openid has limit scopes and authorization has failed on it

## Solution

Add custom parameters, which can help set right values for scopes 
